### PR TITLE
AddProblem-action-requires-stacktrace

### DIFF
--- a/lib/actions/problems/add_problem.dart
+++ b/lib/actions/problems/add_problem.dart
@@ -20,7 +20,7 @@ abstract class AddProblem extends Object
 
   factory AddProblem(
       {required String errorString,
-      String traceString,
+      required String? traceString,
       BuiltMap<String, Object> info}) = _$AddProblem._;
 
   factory AddProblem.by([void Function(AddProblemBuilder) updates]) =

--- a/test/sections/error-handling/UC9/add_problem_reducer_unit_test.dart
+++ b/test/sections/error-handling/UC9/add_problem_reducer_unit_test.dart
@@ -8,7 +8,7 @@ import 'package:the_process/reducers/problems/add_problem.dart';
 void main() {
   group('AddProblemReducer', () {
     test(
-        'Adds Problem to appState.problems and ProblemPageData to appState.pagesData',
+        'adds Problem to appState.problems and ProblemPageData to appState.pagesData',
         () {
       final initialState = AppState.init();
 
@@ -16,14 +16,12 @@ void main() {
       expect(initialState.pagesData.length, 1);
 
       final reducer = AddProblemReducer();
-      final problem = Problem(
-        errorString: 'Problem error message',
-        traceString: StackTrace.current.toString(),
-      );
+      final problem =
+          Problem(errorString: 'Problem error message', traceString: null);
 
       // Invokes the reducer to rebuild appState.
-      final newState = reducer.reducer(
-          initialState, AddProblem(errorString: problem.errorString));
+      final newState = reducer.reducer(initialState,
+          AddProblem(errorString: problem.errorString, traceString: null));
 
       expect(newState.problems.first.errorString, problem.errorString);
       expect(newState.pagesData.length, 2);


### PR DESCRIPTION
Stacktraces should be required for Problems. This was missed on a previous PR.