### PR TITLE
Update google_apis class names

### DIFF
--- a/microservices/create_section/test/test_doubles/apis/docs_api_test_doubles.dart
+++ b/microservices/create_section/test/test_doubles/apis/docs_api_test_doubles.dart
@@ -4,7 +4,7 @@ import 'package:mockito/mockito.dart';
 
 import 'docs_api_test_doubles.mocks.dart';
 
-@GenerateMocks([DocsApi, DocumentsResourceApi])
+@GenerateMocks([DocsApi, DocumentsResource])
 class DocsApiTestDoubles {
   DocsApiTestDoubles();
 }
@@ -14,12 +14,12 @@ enum DocsFunctionNamed { update, create }
 MockDocsApi createDocsApiMockThatReturns(
     {required Document document, required DocsFunctionNamed onCalling}) {
   final mockDocsApi = MockDocsApi();
-  final mockDocumentsResourceApi = MockDocumentsResourceApi();
+  final mockDocumentsResource = MockDocumentsResource();
 
   // Stub the DocsApi mock to return a DocumentsResourceApi mock that in turn
   // returns a Document with a given id when 'create' is called.
-  when(mockDocsApi.documents).thenReturn(mockDocumentsResourceApi);
-  when(mockDocumentsResourceApi.create(any))
+  when(mockDocsApi.documents).thenReturn(mockDocumentsResource);
+  when(mockDocumentsResource.create(any))
       .thenAnswer((_) => Future.value(document));
 
   return mockDocsApi;

--- a/microservices/create_section/test/test_doubles/apis/docs_api_test_doubles.mocks.dart
+++ b/microservices/create_section/test/test_doubles/apis/docs_api_test_doubles.mocks.dart
@@ -10,8 +10,8 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: comment_references
 // ignore_for_file: unnecessary_parenthesis
 
-class _FakeDocumentsResourceApi extends _i1.Fake
-    implements _i2.DocumentsResourceApi {}
+class _FakeDocumentsResource extends _i1.Fake implements _i2.DocumentsResource {
+}
 
 class _FakeBatchUpdateDocumentResponse extends _i1.Fake
     implements _i2.BatchUpdateDocumentResponse {}
@@ -27,17 +27,16 @@ class MockDocsApi extends _i1.Mock implements _i2.DocsApi {
   }
 
   @override
-  _i2.DocumentsResourceApi get documents => (super.noSuchMethod(
-      Invocation.getter(#documents),
-      returnValue: _FakeDocumentsResourceApi()) as _i2.DocumentsResourceApi);
+  _i2.DocumentsResource get documents =>
+      (super.noSuchMethod(Invocation.getter(#documents),
+          returnValue: _FakeDocumentsResource()) as _i2.DocumentsResource);
 }
 
-/// A class which mocks [DocumentsResourceApi].
+/// A class which mocks [DocumentsResource].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockDocumentsResourceApi extends _i1.Mock
-    implements _i2.DocumentsResourceApi {
-  MockDocumentsResourceApi() {
+class MockDocumentsResource extends _i1.Mock implements _i2.DocumentsResource {
+  MockDocumentsResource() {
     _i1.throwOnMissingStub(this);
   }
 

--- a/microservices/create_section/test/test_doubles/apis/drive_api_test_doubles.dart
+++ b/microservices/create_section/test/test_doubles/apis/drive_api_test_doubles.dart
@@ -3,7 +3,7 @@ import 'package:mockito/mockito.dart';
 import 'package:mockito/annotations.dart';
 import 'drive_api_test_doubles.mocks.dart';
 
-@GenerateMocks([DriveApi, FilesResourceApi])
+@GenerateMocks([DriveApi, FilesResource])
 class DriveApiTestDoubles {
   DriveApiTestDoubles();
 }
@@ -13,13 +13,13 @@ enum DriveFunctionNamed { update, create }
 MockDriveApi createDriveApiMockThatReturns(
     {required File file, required DriveFunctionNamed onCalling}) {
   final mockDriveApi = MockDriveApi();
-  final mockFilesResourceApi = MockFilesResourceApi();
+  final mockFilesResource = MockFilesResource();
 
   // Stub the DriveApi mock to return a FilesResourceApi mock that in turn
   // retruns a File, with the given id and parents when 'update' is called.
-  when(mockDriveApi.files).thenReturn(mockFilesResourceApi);
+  when(mockDriveApi.files).thenReturn(mockFilesResource);
   if (onCalling == DriveFunctionNamed.update) {
-    when(mockFilesResourceApi.update(any, any,
+    when(mockFilesResource.update(any, any,
             addParents: anyNamed('addParents'),
             enforceSingleParent: anyNamed('enforceSingleParent'),
             includePermissionsForView: anyNamed('includePermissionsForView'),
@@ -35,7 +35,7 @@ MockDriveApi createDriveApiMockThatReturns(
         .thenAnswer((_) => Future.value(file));
   }
   if (onCalling == DriveFunctionNamed.create) {
-    when(mockFilesResourceApi.create(any,
+    when(mockFilesResource.create(any,
             enforceSingleParent: anyNamed('enforceSingleParent'),
             ignoreDefaultVisibility: anyNamed('ignoreDefaultVisibility'),
             includePermissionsForView: anyNamed('includePermissionsForView'),

--- a/microservices/create_section/test/test_doubles/apis/drive_api_test_doubles.mocks.dart
+++ b/microservices/create_section/test/test_doubles/apis/drive_api_test_doubles.mocks.dart
@@ -11,35 +11,32 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: comment_references
 // ignore_for_file: unnecessary_parenthesis
 
-class _FakeAboutResourceApi extends _i1.Fake implements _i2.AboutResourceApi {}
+class _FakeAboutResource extends _i1.Fake implements _i2.AboutResource {}
 
-class _FakeChangesResourceApi extends _i1.Fake
-    implements _i2.ChangesResourceApi {}
+class _FakeChangesResource extends _i1.Fake implements _i2.ChangesResource {}
 
-class _FakeChannelsResourceApi extends _i1.Fake
-    implements _i2.ChannelsResourceApi {}
+class _FakeChannelsResource extends _i1.Fake implements _i2.ChannelsResource {}
 
-class _FakeCommentsResourceApi extends _i1.Fake
-    implements _i2.CommentsResourceApi {}
+class _FakeCommentsResource extends _i1.Fake implements _i2.CommentsResource {}
 
-class _FakeDrivesResourceApi extends _i1.Fake implements _i2.DrivesResourceApi {
+class _FakeDrivesResource extends _i1.Fake implements _i2.DrivesResource {}
+
+class _FakeFilesResource extends _i1.Fake implements _i2.FilesResource {}
+
+class _FakePermissionsResource extends _i1.Fake
+    implements _i2.PermissionsResource {}
+
+class _FakeRepliesResource extends _i1.Fake implements _i2.RepliesResource {}
+
+class _FakeRevisionsResource extends _i1.Fake implements _i2.RevisionsResource {
 }
 
-class _FakeFilesResourceApi extends _i1.Fake implements _i2.FilesResourceApi {}
-
-class _FakePermissionsResourceApi extends _i1.Fake
-    implements _i2.PermissionsResourceApi {}
-
-class _FakeRepliesResourceApi extends _i1.Fake
-    implements _i2.RepliesResourceApi {}
-
-class _FakeRevisionsResourceApi extends _i1.Fake
-    implements _i2.RevisionsResourceApi {}
-
-class _FakeTeamdrivesResourceApi extends _i1.Fake
-    implements _i2.TeamdrivesResourceApi {}
+class _FakeTeamdrivesResource extends _i1.Fake
+    implements _i2.TeamdrivesResource {}
 
 class _FakeFile extends _i1.Fake implements _i2.File {}
+
+class _FakeObject extends _i1.Fake implements Object {}
 
 class _FakeGeneratedIds extends _i1.Fake implements _i2.GeneratedIds {}
 
@@ -54,53 +51,50 @@ class MockDriveApi extends _i1.Mock implements _i2.DriveApi {
   }
 
   @override
-  _i2.AboutResourceApi get about =>
-      (super.noSuchMethod(Invocation.getter(#about),
-          returnValue: _FakeAboutResourceApi()) as _i2.AboutResourceApi);
+  _i2.AboutResource get about => (super.noSuchMethod(Invocation.getter(#about),
+      returnValue: _FakeAboutResource()) as _i2.AboutResource);
   @override
-  _i2.ChangesResourceApi get changes =>
+  _i2.ChangesResource get changes =>
       (super.noSuchMethod(Invocation.getter(#changes),
-          returnValue: _FakeChangesResourceApi()) as _i2.ChangesResourceApi);
+          returnValue: _FakeChangesResource()) as _i2.ChangesResource);
   @override
-  _i2.ChannelsResourceApi get channels =>
+  _i2.ChannelsResource get channels =>
       (super.noSuchMethod(Invocation.getter(#channels),
-          returnValue: _FakeChannelsResourceApi()) as _i2.ChannelsResourceApi);
+          returnValue: _FakeChannelsResource()) as _i2.ChannelsResource);
   @override
-  _i2.CommentsResourceApi get comments =>
+  _i2.CommentsResource get comments =>
       (super.noSuchMethod(Invocation.getter(#comments),
-          returnValue: _FakeCommentsResourceApi()) as _i2.CommentsResourceApi);
+          returnValue: _FakeCommentsResource()) as _i2.CommentsResource);
   @override
-  _i2.DrivesResourceApi get drives =>
+  _i2.DrivesResource get drives =>
       (super.noSuchMethod(Invocation.getter(#drives),
-          returnValue: _FakeDrivesResourceApi()) as _i2.DrivesResourceApi);
+          returnValue: _FakeDrivesResource()) as _i2.DrivesResource);
   @override
-  _i2.FilesResourceApi get files =>
-      (super.noSuchMethod(Invocation.getter(#files),
-          returnValue: _FakeFilesResourceApi()) as _i2.FilesResourceApi);
+  _i2.FilesResource get files => (super.noSuchMethod(Invocation.getter(#files),
+      returnValue: _FakeFilesResource()) as _i2.FilesResource);
   @override
-  _i2.PermissionsResourceApi get permissions =>
+  _i2.PermissionsResource get permissions =>
       (super.noSuchMethod(Invocation.getter(#permissions),
-              returnValue: _FakePermissionsResourceApi())
-          as _i2.PermissionsResourceApi);
+          returnValue: _FakePermissionsResource()) as _i2.PermissionsResource);
   @override
-  _i2.RepliesResourceApi get replies =>
+  _i2.RepliesResource get replies =>
       (super.noSuchMethod(Invocation.getter(#replies),
-          returnValue: _FakeRepliesResourceApi()) as _i2.RepliesResourceApi);
+          returnValue: _FakeRepliesResource()) as _i2.RepliesResource);
   @override
-  _i2.RevisionsResourceApi get revisions => (super.noSuchMethod(
-      Invocation.getter(#revisions),
-      returnValue: _FakeRevisionsResourceApi()) as _i2.RevisionsResourceApi);
+  _i2.RevisionsResource get revisions =>
+      (super.noSuchMethod(Invocation.getter(#revisions),
+          returnValue: _FakeRevisionsResource()) as _i2.RevisionsResource);
   @override
-  _i2.TeamdrivesResourceApi get teamdrives => (super.noSuchMethod(
-      Invocation.getter(#teamdrives),
-      returnValue: _FakeTeamdrivesResourceApi()) as _i2.TeamdrivesResourceApi);
+  _i2.TeamdrivesResource get teamdrives =>
+      (super.noSuchMethod(Invocation.getter(#teamdrives),
+          returnValue: _FakeTeamdrivesResource()) as _i2.TeamdrivesResource);
 }
 
-/// A class which mocks [FilesResourceApi].
+/// A class which mocks [FilesResource].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockFilesResourceApi extends _i1.Mock implements _i2.FilesResourceApi {
-  MockFilesResourceApi() {
+class MockFilesResource extends _i1.Mock implements _i2.FilesResource {
+  MockFilesResource() {
     _i1.throwOnMissingStub(this);
   }
 
@@ -160,7 +154,7 @@ class MockFilesResourceApi extends _i1.Mock implements _i2.FilesResourceApi {
           }),
           returnValue: Future.value(_FakeFile())) as _i3.Future<_i2.File>);
   @override
-  _i3.Future<dynamic> delete(String? fileId,
+  _i3.Future<void> delete(String? fileId,
           {bool? enforceSingleParent,
           bool? supportsAllDrives,
           bool? supportsTeamDrives,
@@ -174,23 +168,24 @@ class MockFilesResourceApi extends _i1.Mock implements _i2.FilesResourceApi {
             #supportsTeamDrives: supportsTeamDrives,
             #$fields: $fields
           }),
-          returnValue: Future.value(null)) as _i3.Future<dynamic>);
+          returnValue: Future.value(null),
+          returnValueForMissingStub: Future.value()) as _i3.Future<void>);
   @override
-  _i3.Future<dynamic> emptyTrash(
-          {bool? enforceSingleParent, String? $fields}) =>
+  _i3.Future<void> emptyTrash({bool? enforceSingleParent, String? $fields}) =>
       (super.noSuchMethod(
           Invocation.method(#emptyTrash, [],
               {#enforceSingleParent: enforceSingleParent, #$fields: $fields}),
-          returnValue: Future.value(null)) as _i3.Future<dynamic>);
+          returnValue: Future.value(null),
+          returnValueForMissingStub: Future.value()) as _i3.Future<void>);
   @override
-  _i3.Future<dynamic> export(String? fileId, String? mimeType,
+  _i3.Future<Object> export(String? fileId, String? mimeType,
           {String? $fields,
           _i4.DownloadOptions? downloadOptions =
               _i4.DownloadOptions.Metadata}) =>
       (super.noSuchMethod(
           Invocation.method(#export, [fileId, mimeType],
               {#$fields: $fields, #downloadOptions: downloadOptions}),
-          returnValue: Future.value(null)) as _i3.Future<dynamic>);
+          returnValue: Future.value(_FakeObject())) as _i3.Future<Object>);
   @override
   _i3.Future<_i2.GeneratedIds> generateIds(
           {int? count, String? space, String? $fields}) =>
@@ -200,7 +195,7 @@ class MockFilesResourceApi extends _i1.Mock implements _i2.FilesResourceApi {
               returnValue: Future.value(_FakeGeneratedIds()))
           as _i3.Future<_i2.GeneratedIds>);
   @override
-  _i3.Future<dynamic> get(String? fileId,
+  _i3.Future<Object> get(String? fileId,
           {bool? acknowledgeAbuse,
           String? includePermissionsForView,
           bool? supportsAllDrives,
@@ -219,7 +214,7 @@ class MockFilesResourceApi extends _i1.Mock implements _i2.FilesResourceApi {
             #$fields: $fields,
             #downloadOptions: downloadOptions
           }),
-          returnValue: Future.value(null)) as _i3.Future<dynamic>);
+          returnValue: Future.value(_FakeObject())) as _i3.Future<Object>);
   @override
   _i3.Future<_i2.FileList> list(
           {String? corpora,
@@ -291,7 +286,7 @@ class MockFilesResourceApi extends _i1.Mock implements _i2.FilesResourceApi {
           }),
           returnValue: Future.value(_FakeFile())) as _i3.Future<_i2.File>);
   @override
-  _i3.Future<dynamic> watch(_i2.Channel? request, String? fileId,
+  _i3.Future<Object> watch(_i2.Channel? request, String? fileId,
           {bool? acknowledgeAbuse,
           String? includePermissionsForView,
           bool? supportsAllDrives,
@@ -311,5 +306,5 @@ class MockFilesResourceApi extends _i1.Mock implements _i2.FilesResourceApi {
             #$fields: $fields,
             #downloadOptions: downloadOptions
           }),
-          returnValue: Future.value(null)) as _i3.Future<dynamic>);
+          returnValue: Future.value(_FakeObject())) as _i3.Future<Object>);
 }

--- a/microservices/create_section/test/test_doubles/apis/firestore_api_test_doubles.dart
+++ b/microservices/create_section/test/test_doubles/apis/firestore_api_test_doubles.dart
@@ -6,9 +6,9 @@ import 'firestore_api_test_doubles.mocks.dart';
 
 @GenerateMocks([
   FirestoreApi,
-  ProjectsResourceApi,
-  ProjectsDatabasesResourceApi,
-  ProjectsDatabasesDocumentsResourceApi,
+  ProjectsResource,
+  ProjectsDatabasesResource,
+  ProjectsDatabasesDocumentsResource,
 ])
 class FirestoreApiTestDoubles {
   FirestoreApiTestDoubles();
@@ -19,17 +19,17 @@ enum FirestoreFunctionNamed { documentsGet }
 MockFirestoreApi createFirestoreApiMockThatReturns(
     {required Document document, required FirestoreFunctionNamed onCalling}) {
   final mockFirestoreApi = MockFirestoreApi();
-  final mockProjectsResourceApi = MockProjectsResourceApi();
-  final mockProjectsDatabasesResourceApi = MockProjectsDatabasesResourceApi();
-  final mockProjectsDatabasesDocumentsResourceApi =
-      MockProjectsDatabasesDocumentsResourceApi();
+  final mockProjectsResource = MockProjectsResource();
+  final mockProjectsDatabasesResource = MockProjectsDatabasesResource();
+  final mockProjectsDatabasesDocumentsResource =
+      MockProjectsDatabasesDocumentsResource();
 
-  when(mockFirestoreApi.projects).thenReturn(mockProjectsResourceApi);
-  when(mockProjectsResourceApi.databases)
-      .thenReturn(mockProjectsDatabasesResourceApi);
-  when(mockProjectsDatabasesResourceApi.documents)
-      .thenReturn(mockProjectsDatabasesDocumentsResourceApi);
-  when(mockProjectsDatabasesDocumentsResourceApi.get(any,
+  when(mockFirestoreApi.projects).thenReturn(mockProjectsResource);
+  when(mockProjectsResource.databases)
+      .thenReturn(mockProjectsDatabasesResource);
+  when(mockProjectsDatabasesResource.documents)
+      .thenReturn(mockProjectsDatabasesDocumentsResource);
+  when(mockProjectsDatabasesDocumentsResource.get(any,
           mask_fieldPaths: anyNamed('mask_fieldPaths'),
           transaction: anyNamed('transaction'),
           readTime: anyNamed('readTime'),

--- a/microservices/create_section/test/test_doubles/apis/firestore_api_test_doubles.mocks.dart
+++ b/microservices/create_section/test/test_doubles/apis/firestore_api_test_doubles.mocks.dart
@@ -10,23 +10,22 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: comment_references
 // ignore_for_file: unnecessary_parenthesis
 
-class _FakeProjectsResourceApi extends _i1.Fake
-    implements _i2.ProjectsResourceApi {}
+class _FakeProjectsResource extends _i1.Fake implements _i2.ProjectsResource {}
 
-class _FakeProjectsDatabasesResourceApi extends _i1.Fake
-    implements _i2.ProjectsDatabasesResourceApi {}
+class _FakeProjectsDatabasesResource extends _i1.Fake
+    implements _i2.ProjectsDatabasesResource {}
 
-class _FakeProjectsLocationsResourceApi extends _i1.Fake
-    implements _i2.ProjectsLocationsResourceApi {}
+class _FakeProjectsLocationsResource extends _i1.Fake
+    implements _i2.ProjectsLocationsResource {}
 
-class _FakeProjectsDatabasesCollectionGroupsResourceApi extends _i1.Fake
-    implements _i2.ProjectsDatabasesCollectionGroupsResourceApi {}
+class _FakeProjectsDatabasesCollectionGroupsResource extends _i1.Fake
+    implements _i2.ProjectsDatabasesCollectionGroupsResource {}
 
-class _FakeProjectsDatabasesDocumentsResourceApi extends _i1.Fake
-    implements _i2.ProjectsDatabasesDocumentsResourceApi {}
+class _FakeProjectsDatabasesDocumentsResource extends _i1.Fake
+    implements _i2.ProjectsDatabasesDocumentsResource {}
 
-class _FakeProjectsDatabasesOperationsResourceApi extends _i1.Fake
-    implements _i2.ProjectsDatabasesOperationsResourceApi {}
+class _FakeProjectsDatabasesOperationsResource extends _i1.Fake
+    implements _i2.ProjectsDatabasesOperationsResource {}
 
 class _FakeGoogleLongrunningOperation extends _i1.Fake
     implements _i2.GoogleLongrunningOperation {}
@@ -70,56 +69,55 @@ class MockFirestoreApi extends _i1.Mock implements _i2.FirestoreApi {
   }
 
   @override
-  _i2.ProjectsResourceApi get projects =>
+  _i2.ProjectsResource get projects =>
       (super.noSuchMethod(Invocation.getter(#projects),
-          returnValue: _FakeProjectsResourceApi()) as _i2.ProjectsResourceApi);
+          returnValue: _FakeProjectsResource()) as _i2.ProjectsResource);
 }
 
-/// A class which mocks [ProjectsResourceApi].
+/// A class which mocks [ProjectsResource].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockProjectsResourceApi extends _i1.Mock
-    implements _i2.ProjectsResourceApi {
-  MockProjectsResourceApi() {
+class MockProjectsResource extends _i1.Mock implements _i2.ProjectsResource {
+  MockProjectsResource() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i2.ProjectsDatabasesResourceApi get databases =>
+  _i2.ProjectsDatabasesResource get databases =>
       (super.noSuchMethod(Invocation.getter(#databases),
-              returnValue: _FakeProjectsDatabasesResourceApi())
-          as _i2.ProjectsDatabasesResourceApi);
+              returnValue: _FakeProjectsDatabasesResource())
+          as _i2.ProjectsDatabasesResource);
   @override
-  _i2.ProjectsLocationsResourceApi get locations =>
+  _i2.ProjectsLocationsResource get locations =>
       (super.noSuchMethod(Invocation.getter(#locations),
-              returnValue: _FakeProjectsLocationsResourceApi())
-          as _i2.ProjectsLocationsResourceApi);
+              returnValue: _FakeProjectsLocationsResource())
+          as _i2.ProjectsLocationsResource);
 }
 
-/// A class which mocks [ProjectsDatabasesResourceApi].
+/// A class which mocks [ProjectsDatabasesResource].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockProjectsDatabasesResourceApi extends _i1.Mock
-    implements _i2.ProjectsDatabasesResourceApi {
-  MockProjectsDatabasesResourceApi() {
+class MockProjectsDatabasesResource extends _i1.Mock
+    implements _i2.ProjectsDatabasesResource {
+  MockProjectsDatabasesResource() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i2.ProjectsDatabasesCollectionGroupsResourceApi get collectionGroups =>
+  _i2.ProjectsDatabasesCollectionGroupsResource get collectionGroups =>
       (super.noSuchMethod(Invocation.getter(#collectionGroups),
-              returnValue: _FakeProjectsDatabasesCollectionGroupsResourceApi())
-          as _i2.ProjectsDatabasesCollectionGroupsResourceApi);
+              returnValue: _FakeProjectsDatabasesCollectionGroupsResource())
+          as _i2.ProjectsDatabasesCollectionGroupsResource);
   @override
-  _i2.ProjectsDatabasesDocumentsResourceApi get documents =>
+  _i2.ProjectsDatabasesDocumentsResource get documents =>
       (super.noSuchMethod(Invocation.getter(#documents),
-              returnValue: _FakeProjectsDatabasesDocumentsResourceApi())
-          as _i2.ProjectsDatabasesDocumentsResourceApi);
+              returnValue: _FakeProjectsDatabasesDocumentsResource())
+          as _i2.ProjectsDatabasesDocumentsResource);
   @override
-  _i2.ProjectsDatabasesOperationsResourceApi get operations =>
+  _i2.ProjectsDatabasesOperationsResource get operations =>
       (super.noSuchMethod(Invocation.getter(#operations),
-              returnValue: _FakeProjectsDatabasesOperationsResourceApi())
-          as _i2.ProjectsDatabasesOperationsResourceApi);
+              returnValue: _FakeProjectsDatabasesOperationsResource())
+          as _i2.ProjectsDatabasesOperationsResource);
   @override
   _i3.Future<_i2.GoogleLongrunningOperation> exportDocuments(
           _i2.GoogleFirestoreAdminV1ExportDocumentsRequest? request,
@@ -142,12 +140,12 @@ class MockProjectsDatabasesResourceApi extends _i1.Mock
           as _i3.Future<_i2.GoogleLongrunningOperation>);
 }
 
-/// A class which mocks [ProjectsDatabasesDocumentsResourceApi].
+/// A class which mocks [ProjectsDatabasesDocumentsResource].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockProjectsDatabasesDocumentsResourceApi extends _i1.Mock
-    implements _i2.ProjectsDatabasesDocumentsResourceApi {
-  MockProjectsDatabasesDocumentsResourceApi() {
+class MockProjectsDatabasesDocumentsResource extends _i1.Mock
+    implements _i2.ProjectsDatabasesDocumentsResource {
+  MockProjectsDatabasesDocumentsResource() {
     _i1.throwOnMissingStub(this);
   }
 
@@ -221,16 +219,16 @@ class MockProjectsDatabasesDocumentsResourceApi extends _i1.Mock
   @override
   _i3.Future<_i2.Document> get(String? name,
           {List<String>? mask_fieldPaths,
-          String? transaction,
           String? readTime,
+          String? transaction,
           String? $fields}) =>
       (super.noSuchMethod(
               Invocation.method(#get, [
                 name
               ], {
                 #mask_fieldPaths: mask_fieldPaths,
-                #transaction: transaction,
                 #readTime: readTime,
+                #transaction: transaction,
                 #$fields: $fields
               }),
               returnValue: Future.value(_FakeDocument()))
@@ -239,12 +237,12 @@ class MockProjectsDatabasesDocumentsResourceApi extends _i1.Mock
   _i3.Future<_i2.ListDocumentsResponse> list(
           String? parent, String? collectionId,
           {List<String>? mask_fieldPaths,
-          String? pageToken,
           String? orderBy,
+          int? pageSize,
+          String? pageToken,
           String? readTime,
           bool? showMissing,
           String? transaction,
-          int? pageSize,
           String? $fields}) =>
       (super.noSuchMethod(
               Invocation.method(#list, [
@@ -252,12 +250,12 @@ class MockProjectsDatabasesDocumentsResourceApi extends _i1.Mock
                 collectionId
               ], {
                 #mask_fieldPaths: mask_fieldPaths,
-                #pageToken: pageToken,
                 #orderBy: orderBy,
+                #pageSize: pageSize,
+                #pageToken: pageToken,
                 #readTime: readTime,
                 #showMissing: showMissing,
                 #transaction: transaction,
-                #pageSize: pageSize,
                 #$fields: $fields
               }),
               returnValue: Future.value(_FakeListDocumentsResponse()))
@@ -291,9 +289,9 @@ class MockProjectsDatabasesDocumentsResourceApi extends _i1.Mock
   @override
   _i3.Future<_i2.Document> patch(_i2.Document? request, String? name,
           {bool? currentDocument_exists,
-          List<String>? updateMask_fieldPaths,
-          List<String>? mask_fieldPaths,
           String? currentDocument_updateTime,
+          List<String>? mask_fieldPaths,
+          List<String>? updateMask_fieldPaths,
           String? $fields}) =>
       (super.noSuchMethod(
               Invocation.method(#patch, [
@@ -301,9 +299,9 @@ class MockProjectsDatabasesDocumentsResourceApi extends _i1.Mock
                 name
               ], {
                 #currentDocument_exists: currentDocument_exists,
-                #updateMask_fieldPaths: updateMask_fieldPaths,
-                #mask_fieldPaths: mask_fieldPaths,
                 #currentDocument_updateTime: currentDocument_updateTime,
+                #mask_fieldPaths: mask_fieldPaths,
+                #updateMask_fieldPaths: updateMask_fieldPaths,
                 #$fields: $fields
               }),
               returnValue: Future.value(_FakeDocument()))

--- a/microservices/create_section/test/test_doubles/apis/secretmanager_api_test_doubles.dart
+++ b/microservices/create_section/test/test_doubles/apis/secretmanager_api_test_doubles.dart
@@ -7,10 +7,10 @@ import 'package:mockito/mockito.dart';
 import 'secretmanager_api_test_doubles.mocks.dart';
 
 @GenerateMocks([
-  SecretmanagerApi,
-  ProjectsResourceApi,
-  ProjectsSecretsResourceApi,
-  ProjectsSecretsVersionsResourceApi,
+  SecretManagerApi,
+  ProjectsResource,
+  ProjectsSecretsResource,
+  ProjectsSecretsVersionsResource,
   AccessSecretVersionResponse
 ])
 class SecretmanagerApiTestDoubles {
@@ -19,33 +19,32 @@ class SecretmanagerApiTestDoubles {
 
 enum SecretmanagerFunctionNamed { access }
 
-MockSecretmanagerApi createSecretmanagerApiMockThatReturns(
+MockSecretManagerApi createSecretmanagerApiMockThatReturns(
     {required SecretPayload payload,
     required SecretmanagerFunctionNamed onCalling}) {
-  final mockSecretmanagerApi = MockSecretmanagerApi();
-  final mockProjectsResourceApi = MockProjectsResourceApi();
-  final mockProjectsSecretsResourceApi = MockProjectsSecretsResourceApi();
-  final mockProjectsSecretsVersionsResourceApi =
-      MockProjectsSecretsVersionsResourceApi();
+  final mockSecretManagerApi = MockSecretManagerApi();
+  final mockProjectsResource = MockProjectsResource();
+  final mockProjectsSecretsResource = MockProjectsSecretsResource();
+  final mockProjectsSecretsVersionsResource =
+      MockProjectsSecretsVersionsResource();
   final mockAccessSecretVersionResponse = MockAccessSecretVersionResponse();
 
-  when(mockSecretmanagerApi.projects).thenReturn(mockProjectsResourceApi);
-  when(mockProjectsResourceApi.secrets)
-      .thenReturn(mockProjectsSecretsResourceApi);
-  when(mockProjectsSecretsResourceApi.versions)
-      .thenReturn(mockProjectsSecretsVersionsResourceApi);
-  when(mockProjectsSecretsVersionsResourceApi.access(any))
+  when(mockSecretManagerApi.projects).thenReturn(mockProjectsResource);
+  when(mockProjectsResource.secrets).thenReturn(mockProjectsSecretsResource);
+  when(mockProjectsSecretsResource.versions)
+      .thenReturn(mockProjectsSecretsVersionsResource);
+  when(mockProjectsSecretsVersionsResource.access(any))
       .thenAnswer((_) => Future.value(mockAccessSecretVersionResponse));
   when(mockAccessSecretVersionResponse.payload).thenReturn(payload);
 
   SecretPayload();
 
-  return mockSecretmanagerApi;
+  return mockSecretManagerApi;
 }
 
-MockSecretmanagerApi createSecretmanagerApiMockThatThrows(
+MockSecretManagerApi createSecretmanagerApiMockThatThrows(
     {required Exception exception}) {
-  final mockSecretmanagerApi = MockSecretmanagerApi();
+  final mockSecretmanagerApi = MockSecretManagerApi();
   when(mockSecretmanagerApi.projects).thenThrow(exception);
   return mockSecretmanagerApi;
 }

--- a/microservices/create_section/test/test_doubles/apis/secretmanager_api_test_doubles.mocks.dart
+++ b/microservices/create_section/test/test_doubles/apis/secretmanager_api_test_doubles.mocks.dart
@@ -10,17 +10,16 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: comment_references
 // ignore_for_file: unnecessary_parenthesis
 
-class _FakeProjectsResourceApi extends _i1.Fake
-    implements _i2.ProjectsResourceApi {}
+class _FakeProjectsResource extends _i1.Fake implements _i2.ProjectsResource {}
 
-class _FakeProjectsLocationsResourceApi extends _i1.Fake
-    implements _i2.ProjectsLocationsResourceApi {}
+class _FakeProjectsLocationsResource extends _i1.Fake
+    implements _i2.ProjectsLocationsResource {}
 
-class _FakeProjectsSecretsResourceApi extends _i1.Fake
-    implements _i2.ProjectsSecretsResourceApi {}
+class _FakeProjectsSecretsResource extends _i1.Fake
+    implements _i2.ProjectsSecretsResource {}
 
-class _FakeProjectsSecretsVersionsResourceApi extends _i1.Fake
-    implements _i2.ProjectsSecretsVersionsResourceApi {}
+class _FakeProjectsSecretsVersionsResource extends _i1.Fake
+    implements _i2.ProjectsSecretsVersionsResource {}
 
 class _FakeSecretVersion extends _i1.Fake implements _i2.SecretVersion {}
 
@@ -44,55 +43,54 @@ class _FakeListSecretVersionsResponse extends _i1.Fake
 
 class _FakeSecretPayload extends _i1.Fake implements _i2.SecretPayload {}
 
-/// A class which mocks [SecretmanagerApi].
+/// A class which mocks [SecretManagerApi].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSecretmanagerApi extends _i1.Mock implements _i2.SecretmanagerApi {
-  MockSecretmanagerApi() {
+class MockSecretManagerApi extends _i1.Mock implements _i2.SecretManagerApi {
+  MockSecretManagerApi() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i2.ProjectsResourceApi get projects =>
+  _i2.ProjectsResource get projects =>
       (super.noSuchMethod(Invocation.getter(#projects),
-          returnValue: _FakeProjectsResourceApi()) as _i2.ProjectsResourceApi);
+          returnValue: _FakeProjectsResource()) as _i2.ProjectsResource);
 }
 
-/// A class which mocks [ProjectsResourceApi].
+/// A class which mocks [ProjectsResource].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockProjectsResourceApi extends _i1.Mock
-    implements _i2.ProjectsResourceApi {
-  MockProjectsResourceApi() {
+class MockProjectsResource extends _i1.Mock implements _i2.ProjectsResource {
+  MockProjectsResource() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i2.ProjectsLocationsResourceApi get locations =>
+  _i2.ProjectsLocationsResource get locations =>
       (super.noSuchMethod(Invocation.getter(#locations),
-              returnValue: _FakeProjectsLocationsResourceApi())
-          as _i2.ProjectsLocationsResourceApi);
+              returnValue: _FakeProjectsLocationsResource())
+          as _i2.ProjectsLocationsResource);
   @override
-  _i2.ProjectsSecretsResourceApi get secrets =>
+  _i2.ProjectsSecretsResource get secrets =>
       (super.noSuchMethod(Invocation.getter(#secrets),
-              returnValue: _FakeProjectsSecretsResourceApi())
-          as _i2.ProjectsSecretsResourceApi);
+              returnValue: _FakeProjectsSecretsResource())
+          as _i2.ProjectsSecretsResource);
 }
 
-/// A class which mocks [ProjectsSecretsResourceApi].
+/// A class which mocks [ProjectsSecretsResource].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockProjectsSecretsResourceApi extends _i1.Mock
-    implements _i2.ProjectsSecretsResourceApi {
-  MockProjectsSecretsResourceApi() {
+class MockProjectsSecretsResource extends _i1.Mock
+    implements _i2.ProjectsSecretsResource {
+  MockProjectsSecretsResource() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i2.ProjectsSecretsVersionsResourceApi get versions =>
+  _i2.ProjectsSecretsVersionsResource get versions =>
       (super.noSuchMethod(Invocation.getter(#versions),
-              returnValue: _FakeProjectsSecretsVersionsResourceApi())
-          as _i2.ProjectsSecretsVersionsResourceApi);
+              returnValue: _FakeProjectsSecretsVersionsResource())
+          as _i2.ProjectsSecretsVersionsResource);
   @override
   _i3.Future<_i2.SecretVersion> addVersion(
           _i2.AddSecretVersionRequest? request, String? parent,
@@ -167,12 +165,12 @@ class MockProjectsSecretsResourceApi extends _i1.Mock
           as _i3.Future<_i2.TestIamPermissionsResponse>);
 }
 
-/// A class which mocks [ProjectsSecretsVersionsResourceApi].
+/// A class which mocks [ProjectsSecretsVersionsResource].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockProjectsSecretsVersionsResourceApi extends _i1.Mock
-    implements _i2.ProjectsSecretsVersionsResourceApi {
-  MockProjectsSecretsVersionsResourceApi() {
+class MockProjectsSecretsVersionsResource extends _i1.Mock
+    implements _i2.ProjectsSecretsVersionsResource {
+  MockProjectsSecretsVersionsResource() {
     _i1.throwOnMissingStub(this);
   }
 


### PR DESCRIPTION
There was a breaking change in the google_apis package - the error messages were a bit misleading and I thought the problem was about mocking const classes.  

So this PR is fixing https://app.asana.com/0/1199935497474892/1199960339067360 